### PR TITLE
docs: Add initial documentation for each of the modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # terraform-aws-flowfuse
 Repository with terraform modules for setting up AWS infrastructure to host FlowFuse platform
+
+## Modules documentation
+
+- [eks](./eks/README.md)
+- [lb-domain](./lb-domain/README.md)
+- [rds](./rds/README.md)
+- [route53](./route53/README.md)
+- [ses](./ses/README.md)
+- [vpc](./vpc/README.md)
+- [vpc-peering](./vpc-peering/README.md)

--- a/eks/README.md
+++ b/eks/README.md
@@ -10,6 +10,34 @@ The module supports the following:
 - Optional creation and management of related AWS resources such as IAM policies and roles.
 - Support for enabling various EKS cluster features such as detailed monitoring and cluster autoscaling.
 
+## Usage
+
+`Replace AWS_ACCOUNT_ID with your AWS account ID`
+
+```hcl
+  module "eks" {
+    source = "git::https://github.com/FlowFuse/terraform-aws-flowfuse.git//eks?ref=main"
+
+    namespace = "my-company"
+    stage     = "production"
+
+    kubernetes_version           = "1.29"
+    eks_access_entry_map         = {
+      "arn:aws:iam::AWS_ACCOUNT_ID:user/your-user" = {
+        access_policy_associations = {
+          ClusterAdmin = {}
+        }
+      }
+    }
+
+    tags = {
+      Environment = "production"
+      Project = "my-project"
+      terraform = true
+    }
+  }
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -51,9 +79,7 @@ The module supports the following:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_addons"></a> [addons](#input\_addons) | Manages [`aws_eks_addon`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) resources. | <pre>list(object({<br>    addon_name                  = string<br>    addon_version               = string<br>    resolve_conflicts           = optional(string, null)<br>    resolve_conflicts_on_create = optional(string, null)<br>    resolve_conflicts_on_update = optional(string, null)<br>    service_account_role_arn    = string<br>  }))</pre> | `[]` | no |
-| <a name="input_cluster_autoscaler_enabled"></a> [cluster\_autoscaler\_enabled](#input\_cluster\_autoscaler\_enabled) | n/a | `bool` | `true` | no |
 | <a name="input_cluster_log_retention_period"></a> [cluster\_log\_retention\_period](#input\_cluster\_log\_retention\_period) | The value in days for the retention period of the log group. | `number` | `14` | no |
-| <a name="input_detailed_monitoring_enabled"></a> [detailed\_monitoring\_enabled](#input\_detailed\_monitoring\_enabled) | n/a | `bool` | `false` | no |
 | <a name="input_eks_access_entry_map"></a> [eks\_access\_entry\_map](#input\_eks\_access\_entry\_map) | Represents a map of access entries for an EKS cluster. Each entry in the map represents the access configuration for a specific principal ARN | <pre>map(object({<br>    # key is principal_arn<br>    user_name = optional(string)<br>    # Cannot assign "system:*" groups to IAM users, use ClusterAdmin and Admin instead<br>    kubernetes_groups = optional(list(string), [])<br>    type              = optional(string, "STANDARD")<br>    access_policy_associations = optional(map(object({<br>      # key is policy_arn or policy_name<br>      access_scope = optional(object({<br>        type       = optional(string, "cluster")<br>        namespaces = optional(list(string))<br>      }), {}) # access_scope<br>    })), {})  # access_policy_associations<br>  }))</pre> | `{}` | no |
 | <a name="input_eks_node_groups"></a> [eks\_node\_groups](#input\_eks\_node\_groups) | Map of maps containing configuration of EKS node groups to be created. The key is the name of the node group.<br>    * `name` - Node Group name<br>    * `instance_types` - EC2 instance types to use for the node group<br>    * `ami_type` - AMI type for the instance<br>    * `desired_size` - desired number of instances<br>    * `min_size` - minimum number of instances<br>    * `max_size` - maximum number of instances<br>    * `kubernetes_labels` - Kubernetes labels to apply to the node group<br>    * `cluster_autoscaler_enabled` - whether to enable the cluster autoscaler for the node group<br>    * `detailed_monitoring_enabled` - whether to enable detailed monitoring for the node group<br>    * `attributes` - Additional attributes (e.g. `["eks"]`) | <pre>map(object({<br>    name                        = string<br>    instance_types              = list(string)<br>    ami_type                    = string<br>    desired_size                = number<br>    min_size                    = number<br>    max_size                    = number<br>    kubernetes_labels           = map(string)<br>    cluster_autoscaler_enabled  = bool<br>    detailed_monitoring_enabled = bool<br>    attributes                  = list(string)<br>  }))</pre> | <pre>{<br>  "management": {<br>    "ami_type": "AL2_x86_64",<br>    "attributes": [<br>      "management"<br>    ],<br>    "cluster_autoscaler_enabled": true,<br>    "desired_size": 1,<br>    "detailed_monitoring_enabled": false,<br>    "instance_types": [<br>      "m6a.xlarge"<br>    ],<br>    "kubernetes_labels": {<br>      "role": "management"<br>    },<br>    "max_size": 2,<br>    "min_size": 1,<br>    "name": "management"<br>  },<br>  "projects": {<br>    "ami_type": "AL2_ARM_64",<br>    "attributes": [<br>      "projects"<br>    ],<br>    "cluster_autoscaler_enabled": true,<br>    "desired_size": 1,<br>    "detailed_monitoring_enabled": false,<br>    "instance_types": [<br>      "t4g.large"<br>    ],<br>    "kubernetes_labels": {<br>      "role": "projects"<br>    },<br>    "max_size": 4,<br>    "min_size": 1,<br>    "name": "projects"<br>  }<br>}</pre> | no |
 | <a name="input_enabled_cluster_log_types"></a> [enabled\_cluster\_log\_types](#input\_enabled\_cluster\_log\_types) | A list of the desired control plane logging to enable. Available values: api, audit, authenticator, controllerManager, scheduler | `list(string)` | <pre>[<br>  "api",<br>  "audit",<br>  "authenticator",<br>  "controllerManager",<br>  "scheduler"<br>]</pre> | no |

--- a/eks/README.md
+++ b/eks/README.md
@@ -1,0 +1,72 @@
+# Terraform EKS module
+
+Terraform module which creates [FlowFuse-specific](https://flowfuse.com) [EKS](https://aws.amazon.com/eks/) cluster and node groups on AWS.
+
+The module supports the following:
+
+- Creation of an EKS cluster with configurable Kubernetes version.
+- Management of EKS node groups, with support for multiple instance types, AMI types, and autoscaling configurations.
+- Integration with AWS IAM for access control.
+- Optional creation and management of related AWS resources such as IAM policies and roles.
+- Support for enabling various EKS cluster features such as detailed monitoring and cluster autoscaling.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.48 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.43.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | 4.0.0 |
+| <a name="module_node_groups"></a> [node\_groups](#module\_node\_groups) | cloudposse/eks-node-group/aws | 2.12.0 |
+| <a name="module_vpc_cni_eks_iam_role"></a> [vpc\_cni\_eks\_iam\_role](#module\_vpc\_cni\_eks\_iam\_role) | cloudposse/eks-iam-role/aws | 2.1.1 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role_policy_attachment.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vpc_cni_ipv6](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_session_context.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_session_context) | data source |
+| [aws_security_group.vpc_default_security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+| [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_subnets.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_addons"></a> [addons](#input\_addons) | Manages [`aws_eks_addon`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) resources. | <pre>list(object({<br>    addon_name                  = string<br>    addon_version               = string<br>    resolve_conflicts           = optional(string, null)<br>    resolve_conflicts_on_create = optional(string, null)<br>    resolve_conflicts_on_update = optional(string, null)<br>    service_account_role_arn    = string<br>  }))</pre> | `[]` | no |
+| <a name="input_cluster_autoscaler_enabled"></a> [cluster\_autoscaler\_enabled](#input\_cluster\_autoscaler\_enabled) | n/a | `bool` | `true` | no |
+| <a name="input_cluster_log_retention_period"></a> [cluster\_log\_retention\_period](#input\_cluster\_log\_retention\_period) | The value in days for the retention period of the log group. | `number` | `14` | no |
+| <a name="input_detailed_monitoring_enabled"></a> [detailed\_monitoring\_enabled](#input\_detailed\_monitoring\_enabled) | n/a | `bool` | `false` | no |
+| <a name="input_eks_access_entry_map"></a> [eks\_access\_entry\_map](#input\_eks\_access\_entry\_map) | Represents a map of access entries for an EKS cluster. Each entry in the map represents the access configuration for a specific principal ARN | <pre>map(object({<br>    # key is principal_arn<br>    user_name = optional(string)<br>    # Cannot assign "system:*" groups to IAM users, use ClusterAdmin and Admin instead<br>    kubernetes_groups = optional(list(string), [])<br>    type              = optional(string, "STANDARD")<br>    access_policy_associations = optional(map(object({<br>      # key is policy_arn or policy_name<br>      access_scope = optional(object({<br>        type       = optional(string, "cluster")<br>        namespaces = optional(list(string))<br>      }), {}) # access_scope<br>    })), {})  # access_policy_associations<br>  }))</pre> | `{}` | no |
+| <a name="input_eks_node_groups"></a> [eks\_node\_groups](#input\_eks\_node\_groups) | Map of maps containing configuration of EKS node groups to be created. The key is the name of the node group.<br>    * `name` - Node Group name<br>    * `instance_types` - EC2 instance types to use for the node group<br>    * `ami_type` - AMI type for the instance<br>    * `desired_size` - desired number of instances<br>    * `min_size` - minimum number of instances<br>    * `max_size` - maximum number of instances<br>    * `kubernetes_labels` - Kubernetes labels to apply to the node group<br>    * `cluster_autoscaler_enabled` - whether to enable the cluster autoscaler for the node group<br>    * `detailed_monitoring_enabled` - whether to enable detailed monitoring for the node group<br>    * `attributes` - Additional attributes (e.g. `["eks"]`) | <pre>map(object({<br>    name                        = string<br>    instance_types              = list(string)<br>    ami_type                    = string<br>    desired_size                = number<br>    min_size                    = number<br>    max_size                    = number<br>    kubernetes_labels           = map(string)<br>    cluster_autoscaler_enabled  = bool<br>    detailed_monitoring_enabled = bool<br>    attributes                  = list(string)<br>  }))</pre> | <pre>{<br>  "management": {<br>    "ami_type": "AL2_x86_64",<br>    "attributes": [<br>      "management"<br>    ],<br>    "cluster_autoscaler_enabled": true,<br>    "desired_size": 1,<br>    "detailed_monitoring_enabled": false,<br>    "instance_types": [<br>      "m6a.xlarge"<br>    ],<br>    "kubernetes_labels": {<br>      "role": "management"<br>    },<br>    "max_size": 2,<br>    "min_size": 1,<br>    "name": "management"<br>  },<br>  "projects": {<br>    "ami_type": "AL2_ARM_64",<br>    "attributes": [<br>      "projects"<br>    ],<br>    "cluster_autoscaler_enabled": true,<br>    "desired_size": 1,<br>    "detailed_monitoring_enabled": false,<br>    "instance_types": [<br>      "t4g.large"<br>    ],<br>    "kubernetes_labels": {<br>      "role": "projects"<br>    },<br>    "max_size": 4,<br>    "min_size": 1,<br>    "name": "projects"<br>  }<br>}</pre> | no |
+| <a name="input_enabled_cluster_log_types"></a> [enabled\_cluster\_log\_types](#input\_enabled\_cluster\_log\_types) | A list of the desired control plane logging to enable. Available values: api, audit, authenticator, controllerManager, scheduler | `list(string)` | <pre>[<br>  "api",<br>  "audit",<br>  "authenticator",<br>  "controllerManager",<br>  "scheduler"<br>]</pre> | no |
+| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | The desired Kubernetes master version. If you do not specify a value, the latest available version is used. | `string` | `"1.26"` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | n/a | yes |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | n/a |
+| <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | n/a |
+| <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | n/a |
+<!-- END_TF_DOCS -->

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -1,10 +1,10 @@
 variable "namespace" {
-  type = string
+  type        = string
   description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
 }
 
 variable "stage" {
-  type = string
+  type        = string
   description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
 }
 
@@ -37,25 +37,25 @@ variable "eks_access_entry_map" {
     })), {})  # access_policy_associations
   }))
   description = "Represents a map of access entries for an EKS cluster. Each entry in the map represents the access configuration for a specific principal ARN"
-  default = {}
+  default     = {}
 }
 
 variable "kubernetes_version" {
-  type    = string
+  type        = string
   description = "The desired Kubernetes master version. If you do not specify a value, the latest available version is used."
-  default = "1.26"
+  default     = "1.26"
 }
 
 variable "enabled_cluster_log_types" {
-  type    = list(string)
+  type        = list(string)
   description = "A list of the desired control plane logging to enable. Available values: api, audit, authenticator, controllerManager, scheduler"
-  default = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+  default     = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 }
 
 variable "cluster_log_retention_period" {
-  type    = number
+  type        = number
   description = "The value in days for the retention period of the log group."
-  default = 14
+  default     = 14
 }
 
 variable "eks_node_groups" {
@@ -116,7 +116,7 @@ variable "eks_node_groups" {
   }
 }
 variable "tags" {
-  type    = map(string)
+  type        = map(string)
   description = "A map of tags to add to all resources"
-  default = {}
+  default     = {}
 }

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -1,9 +1,11 @@
 variable "namespace" {
   type = string
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
 }
 
 variable "stage" {
   type = string
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
 }
 
 variable "addons" {
@@ -34,49 +36,26 @@ variable "eks_access_entry_map" {
       }), {}) # access_scope
     })), {})  # access_policy_associations
   }))
+  description = "Represents a map of access entries for an EKS cluster. Each entry in the map represents the access configuration for a specific principal ARN"
   default = {}
 }
 
 variable "kubernetes_version" {
   type    = string
+  description = "The desired Kubernetes master version. If you do not specify a value, the latest available version is used."
   default = "1.26"
 }
 
 variable "enabled_cluster_log_types" {
   type    = list(string)
+  description = "A list of the desired control plane logging to enable. Available values: api, audit, authenticator, controllerManager, scheduler"
   default = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 }
 
 variable "cluster_log_retention_period" {
   type    = number
+  description = "The value in days for the retention period of the log group."
   default = 14
-}
-
-variable "instance_types" {
-  type    = list(string)
-  default = ["m6a.xlarge"]
-}
-
-variable "desired_size" {
-  type    = number
-  default = 1
-}
-
-variable "min_size" {
-  type    = number
-  default = 1
-}
-
-variable "max_size" {
-  type    = number
-  default = 2
-}
-
-variable "kubernetes_labels" {
-  type = map(string)
-  default = {
-    terraform = "true"
-  }
 }
 
 variable "cluster_autoscaler_enabled" {
@@ -102,6 +81,19 @@ variable "eks_node_groups" {
     detailed_monitoring_enabled = bool
     attributes                  = list(string)
   }))
+  description = <<EOT
+    Map of maps containing configuration of EKS node groups to be created. The key is the name of the node group.
+    * `name` - Node Group name
+    * `instance_types` - EC2 instance types to use for the node group
+    * `ami_type` - AMI type for the instance
+    * `desired_size` - desired number of instances
+    * `min_size` - minimum number of instances
+    * `max_size` - maximum number of instances
+    * `kubernetes_labels` - Kubernetes labels to apply to the node group
+    * `cluster_autoscaler_enabled` - whether to enable the cluster autoscaler for the node group
+    * `detailed_monitoring_enabled` - whether to enable detailed monitoring for the node group
+    * `attributes` - Additional attributes (e.g. `["eks"]`)
+  EOT
   default = {
     management = {
       name           = "management"
@@ -140,5 +132,6 @@ variable "route53_zone_name" {
 
 variable "tags" {
   type    = map(string)
+  description = 
   default = {}
 }

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -132,6 +132,6 @@ variable "route53_zone_name" {
 
 variable "tags" {
   type    = map(string)
-  description = 
+  description = "A map of tags to add to all resources"
   default = {}
 }

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -58,16 +58,6 @@ variable "cluster_log_retention_period" {
   default = 14
 }
 
-variable "cluster_autoscaler_enabled" {
-  type    = bool
-  default = true
-}
-
-variable "detailed_monitoring_enabled" {
-  type    = bool
-  default = false
-}
-
 variable "eks_node_groups" {
   type = map(object({
     name                        = string
@@ -125,11 +115,6 @@ variable "eks_node_groups" {
     },
   }
 }
-
-variable "route53_zone_name" {
-  type = string
-}
-
 variable "tags" {
   type    = map(string)
   description = "A map of tags to add to all resources"

--- a/lb-domain/README.md
+++ b/lb-domain/README.md
@@ -2,6 +2,24 @@
 
 The terraform module used to create DNS records in Route53 zone for existing Network Load Balancer.
 
+## Usage
+
+```hcl
+  module "lb_domain" {
+    source  = "git::https://github.com/flowFuse/terraform-aws-flowfuse.git//lb-domain?ref=main"
+
+    namespace = "my-company"
+    route53_zone_name = "example.com"
+    stage = "production"
+
+    tags = {
+      Environment = "production"
+      Project = "my-project"
+      terraform = true
+    }
+  }
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/lb-domain/README.md
+++ b/lb-domain/README.md
@@ -1,0 +1,42 @@
+# Terraform lb-domain module
+
+The terraform module used to create DNS records in Route53 zone for existing Network Load Balancer.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.48 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.45.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_records"></a> [records](#module\_records) | terraform-aws-modules/route53/aws//modules/records | ~> 2.11 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_lb.ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | n/a | yes |
+| <a name="input_route53_zone_name"></a> [route53\_zone\_name](#input\_route53\_zone\_name) | The name of the Route53 zone | `string` | n/a | yes |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/lb-domain/variables.tf
+++ b/lb-domain/variables.tf
@@ -1,16 +1,20 @@
 variable "namespace" {
-  type = string
+  type        = string
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
 }
 
 variable "stage" {
-  type = string
+  type        = string
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
 }
 
 variable "route53_zone_name" {
-  type = string
+  type        = string
+  description = "The name of the Route53 zone"
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  description = "A map of tags to add to all resources"
+  default     = {}
 }

--- a/rds/README.md
+++ b/rds/README.md
@@ -1,0 +1,55 @@
+# 
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.48 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.44.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_primary"></a> [primary](#module\_primary) | cloudposse/rds/aws | 1.1.0 |
+| <a name="module_rds_subnets"></a> [rds\_subnets](#module\_rds\_subnets) | cloudposse/dynamic-subnets/aws | 2.4.2 |
+| <a name="module_rds_vpc"></a> [rds\_vpc](#module\_rds\_vpc) | cloudposse/vpc/aws | 2.2.0 |
+| <a name="module_replica"></a> [replica](#module\_replica) | cloudposse/rds/aws | 1.1.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [random_password.database_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [aws_availability_zones.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cidr"></a> [cidr](#input\_cidr) | The CIDR block for the RDS VPC | `string` | `"172.24.124.0/24"` | no |
+| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | The name of the database to create | `string` | `"flowforge"` | no |
+| <a name="input_database_port"></a> [database\_port](#input\_database\_port) | The port on which the database accepts connections | `number` | `5432` | no |
+| <a name="input_database_user"></a> [database\_user](#input\_database\_user) | The master username for the database. Must be all lowercase | `string` | `"forge"` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | n/a | yes |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_database_address"></a> [database\_address](#output\_database\_address) | n/a |
+| <a name="output_database_name"></a> [database\_name](#output\_database\_name) | n/a |
+| <a name="output_database_password"></a> [database\_password](#output\_database\_password) | n/a |
+| <a name="output_database_user"></a> [database\_user](#output\_database\_user) | n/a |
+<!-- END_TF_DOCS -->

--- a/rds/README.md
+++ b/rds/README.md
@@ -1,4 +1,31 @@
-# 
+# Terraform RDS module
+
+This Terraform module is designed to create and manage FlowFuse-specific [Amazon RDS (Relational Database Service)](https://aws.amazon.com/rds/) instances.
+
+The module supports the following:
+
+- Creation of RDS primary and replica instances
+- Creation of dedicated VPS and subnets for the RDS instances
+- Creation of FlowFuse-specific databases
+
+The module also provides several outputs including the database address, name, password, and user.
+
+## Usage
+
+```hcl
+  module "rds" {
+    source = "git::https://github.com/flowFuse/terraform-aws-flowfuse.git//rds?ref=main"
+
+    namespace = "my-company"
+    stage     = "production"
+
+    tags = {
+      Environment = "production"
+      Project = "my-project"
+      terraform = true
+    }
+  }
+```
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -1,32 +1,39 @@
 variable "namespace" {
-  type = string
+  type        = string
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
 }
 
 variable "stage" {
-  type = string
+  type        = string
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
 }
 
 variable "cidr" {
-  type    = string
-  default = "172.24.124.0/24"
+  type        = string
+  description = "The CIDR block for the RDS VPC"
+  default     = "172.24.124.0/24"
 }
 
 variable "database_user" {
-  type    = string
-  default = "forge"
+  type        = string
+  description = "The master username for the database. Must be all lowercase"
+  default     = "forge"
 }
 
 variable "database_name" {
-  type    = string
-  default = "flowforge"
+  type        = string
+  description = "The name of the database to create"
+  default     = "flowforge"
 }
 
 variable "database_port" {
-  type    = number
-  default = 5432
+  type        = number
+  description = "The port on which the database accepts connections"
+  default     = 5432
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  description = "A map of tags to add to all resources"
+  default     = {}
 }

--- a/route53/README.md
+++ b/route53/README.md
@@ -1,0 +1,67 @@
+# Terraform Route53 Module
+
+This Terraform module is designed to manage [AWS Route53](https://aws.amazon.com/route53/) zone and associated [ACM certificates](https://aws.amazon.com/certificate-manager/).
+
+The module supports the following:
+
+- Creation of defined route53 zone
+- Creation of certificate required to run FlowFuse self-hosted platform
+
+The module also provides several outputs including the ACM certificate ARN and domain DNS records.
+
+## Usage
+```hcl
+module "domain" {
+  source = "git::https://github.com/flowFuse/terraform-aws-flowfuse.git//route53?ref=main"
+
+  namespace = "my-company"
+  stage     = "production"
+
+  route53_zone_name = "example.com"
+
+  tags = {
+      Environment = "production"
+      Project = "my-project"
+      terraform = true
+    }
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.48 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_acm_request_certificate"></a> [acm\_request\_certificate](#module\_acm\_request\_certificate) | cloudposse/acm-request-certificate/aws | 0.18.0 |
+| <a name="module_zones"></a> [zones](#module\_zones) | terraform-aws-modules/route53/aws//modules/zones | ~> 2.11 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | n/a | yes |
+| <a name="input_route53_zone_name"></a> [route53\_zone\_name](#input\_route53\_zone\_name) | The name of the Route53 zone to create | `string` | n/a | yes |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_acm_certificate_arn"></a> [acm\_certificate\_arn](#output\_acm\_certificate\_arn) | n/a |
+| <a name="output_domain_dns_records"></a> [domain\_dns\_records](#output\_domain\_dns\_records) | n/a |
+<!-- END_TF_DOCS -->

--- a/route53/variables.tf
+++ b/route53/variables.tf
@@ -1,16 +1,20 @@
 variable "namespace" {
-  type = string
+  type        = string
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
 }
 
 variable "stage" {
-  type = string
+  type        = string
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
 }
 
 variable "route53_zone_name" {
-  type = string
+  type        = string
+  description = "The name of the Route53 zone to create"
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  description = "A map of tags to add to all resources"
+  default     = {}
 }

--- a/ses/README.md
+++ b/ses/README.md
@@ -1,0 +1,69 @@
+# Terraform SES Module
+
+This Terraform module sets up SES (Simple Email Service) related resources in AWS. It creates DNS records in Route53, IAM roles, and other necessary resources for SES to function properly.
+
+## Usage
+
+```hcl
+  module "ses" {
+    source = "git::https://github.com/FlowFuse/terraform-aws-flowfuse.git//ses?ref=main"
+
+    namespace = "my-company"
+    stage     = "production"
+
+    route53_zone_name = "example.com"
+
+    tags = {
+        Environment = "production"
+        Project = "my-project"
+        terraform = true
+      }
+  }
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.48 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.44.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_dmarc_record"></a> [dmarc\_record](#module\_dmarc\_record) | terraform-aws-modules/route53/aws//modules/records | ~> 2.11 |
+| <a name="module_eks_ses_iam_role"></a> [eks\_ses\_iam\_role](#module\_eks\_ses\_iam\_role) | cloudposse/eks-iam-role/aws | 2.1.1 |
+| <a name="module_ses"></a> [ses](#module\_ses) | cloudposse/ses/aws | 0.25.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_iam_policy_document.ses](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_route53_zone.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | n/a | yes |
+| <a name="input_route53_zone_name"></a> [route53\_zone\_name](#input\_route53\_zone\_name) | The name of the Route53 zone within which to create SES-related records | `string` | n/a | yes |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_flowfuse_ses_role_arn"></a> [flowfuse\_ses\_role\_arn](#output\_flowfuse\_ses\_role\_arn) | n/a |
+<!-- END_TF_DOCS -->

--- a/ses/variables.tf
+++ b/ses/variables.tf
@@ -1,16 +1,20 @@
 variable "namespace" {
-  type = string
+  type        = string
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
 }
 
 variable "stage" {
-  type = string
+  type        = string
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
 }
 
 variable "route53_zone_name" {
-  type = string
+  type        = string
+  description = "The name of the Route53 zone within which to create SES-related records"
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  description = "A map of tags to add to all resources"
+  default     = {}
 }

--- a/vpc-peering/README.md
+++ b/vpc-peering/README.md
@@ -1,0 +1,60 @@
+# Terraform vpc-peering Module
+
+This Terraform module sets up [VPC peering](https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html) between two VPCs in AWS. It creates a connection between VPC created with our [VPC](https://github.com/FlowFuse/terraform-aws-flowfuse/tree/main/vpc) and [RDS](https://github.com/FlowFuse/terraform-aws-flowfuse/tree/main/rds) modules. 
+Additionally, it sets up the necessary routes to enable communication between the VPCs.
+
+## Usage
+
+```hcl
+  module "peering" {
+    source = "git::https://github.com/FlowFuse/terraform-aws-flowfuse.git//vpc-peering?ref=main"
+
+    namespace = "my-company"
+    stage     = "production"
+
+    tags = {
+      Environment = "production"
+      Project = "my-project"
+      terraform = true
+    }
+  }
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.48 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.44.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_vpc_peering"></a> [vpc\_peering](#module\_vpc\_peering) | cloudposse/vpc-peering/aws | 1.0.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_vpc.database](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+| [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | n/a | yes |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/vpc-peering/variables.tf
+++ b/vpc-peering/variables.tf
@@ -1,12 +1,15 @@
 variable "namespace" {
-  type = string
+  type        = string
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
 }
 
 variable "stage" {
-  type = string
+  type        = string
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  description = "A map of tags to add to all resources"
+  default     = {}
 }

--- a/vpc/README.md
+++ b/vpc/README.md
@@ -1,0 +1,60 @@
+# Terraform VPC Module
+
+The VPC module is responsible for creating a Virtual Private Cloud (VPC) in AWS. It provisions the necessary resources such as subnets and availability zones.
+
+## Usage
+
+```hcl
+  module "vpc" {
+    source = "git::https://github.com/FlowFuse/terraform-aws-flowfuse.git//vpc?ref=main"
+
+    namespace = "my-company"
+    stage     = "production"
+
+    tags = {
+      Environment = "production"
+      Project = "my-project"
+      terraform = true
+    }
+  }
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.48 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.42.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_subnets"></a> [subnets](#module\_subnets) | cloudposse/dynamic-subnets/aws | 2.4.2 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/vpc/aws | 2.2.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_availability_zones.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cidr"></a> [cidr](#input\_cidr) | The CIDR block for the VPC. | `string` | `"10.0.0.0/16"` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | n/a | yes |
+| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -1,17 +1,21 @@
 variable "namespace" {
-  type = string
+  type        = string
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
 }
 
 variable "stage" {
-  type = string
+  type        = string
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
 }
 
 variable "cidr" {
-  type    = string
-  default = "10.0.0.0/16"
+  type        = string
+  description = "The CIDR block for the VPC."
+  default     = "10.0.0.0/16"
 }
 
 variable "tags" {
-  type    = map(string)
-  default = {}
+  type        = map(string)
+  description = "A map of tags to add to all resources"
+  default     = {}
 }


### PR DESCRIPTION
## Description

This pull request adds module documentation for the eks, lb-domain, rds, route53, ses, vpc, and vpc-peering modules. The documentation includes descriptions of the resources used in each module and example usage. Additionally, the main readme file now includes links to the documentation of each module.

Additionally, this PR removes unused variables from the EKS module.

## Related Issue(s)

https://github.com/FlowFuse/terraform-aws-flowfuse/issues/5

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

