### PR TITLE
[eks] Add `cluster_oidc_issuer_url` output

### DIFF
--- a/eks/README.md
+++ b/eks/README.md
@@ -49,7 +49,7 @@ The module supports the following:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.43.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.49.0 |
 
 ## Modules
 
@@ -93,6 +93,7 @@ The module supports the following:
 | Name | Description |
 |------|-------------|
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | n/a |
+| <a name="output_cluster_oidc_issuer_url"></a> [cluster\_oidc\_issuer\_url](#output\_cluster\_oidc\_issuer\_url) | n/a |
 | <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | n/a |
 | <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | n/a |
 <!-- END_TF_DOCS -->

--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -1,3 +1,7 @@
 output "cluster_name" {
   value = module.eks_cluster.eks_cluster_id
 }
+
+output "cluster_oidc_issuer_url" {
+  value = module.eks_cluster.eks_cluster_identity_oidc_issuer
+}


### PR DESCRIPTION
## Description

This pull request adds the `cluster_oidc_issuer_url` output to the EKS module.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

