### PR TITLE
feat[lb-domain]: add possibility to create dns record for "custom domains" feature

### DIFF
--- a/lb-domain/main.tf
+++ b/lb-domain/main.tf
@@ -5,13 +5,16 @@ data "aws_lb" "ingress" {
   }
 }
 
-module "records" {
-  source  = "terraform-aws-modules/route53/aws//modules/records"
-  version = "~> 2.11"
+data "aws_lb" "custom_domains_ingress" {
+  tags = {
+    Namespace     = var.namespace
+    Stage         = var.stage
+    custom_domains= "true"
+  }
+}
 
-  zone_name = var.route53_zone_name
-
-  records = [
+locals {
+  main_dns_records = [
     {
       name = "*"
       type = "CNAME"
@@ -21,4 +24,28 @@ module "records" {
       ]
     }
   ]
+
+  custom_domain_dns_record = {
+      name = "custom-loadbalancer"
+      type = "CNAME"
+      ttl  = 300
+      records = [
+        data.aws_lb.custom_domains_ingress.dns_name
+      ]
+    }
+
+  dns_records = concat(
+    local.main_dns_records,
+    var.create_custom_domain_record ? [ local.custom_domain_dns_record ] : []
+  )
+}
+
+
+module "records" {
+  source  = "terraform-aws-modules/route53/aws//modules/records"
+  version = "~> 2.11"
+
+  zone_name = var.route53_zone_name
+
+  records = local.dns_records
 }

--- a/lb-domain/main.tf
+++ b/lb-domain/main.tf
@@ -26,7 +26,7 @@ locals {
   ]
 
   custom_domain_dns_record = {
-      name = "custom-loadbalancer"
+      name = var.custom_domain_record_value
       type = "CNAME"
       ttl  = 300
       records = [

--- a/lb-domain/main.tf
+++ b/lb-domain/main.tf
@@ -6,6 +6,7 @@ data "aws_lb" "ingress" {
 }
 
 data "aws_lb" "custom_domains_ingress" {
+  count = var.create_custom_domain_record ? 1 : 0
   tags = {
     Namespace     = var.namespace
     Stage         = var.stage
@@ -25,14 +26,14 @@ locals {
     }
   ]
 
-  custom_domain_dns_record = {
+  custom_domain_dns_record = var.create_custom_domain_record ? {
       name = var.custom_domain_record_value
       type = "CNAME"
       ttl  = 300
       records = [
-        data.aws_lb.custom_domains_ingress.dns_name
+        data.aws_lb.custom_domains_ingress.0.dns_name
       ]
-    }
+    } : null
 
   dns_records = concat(
     local.main_dns_records,

--- a/lb-domain/variables.tf
+++ b/lb-domain/variables.tf
@@ -13,6 +13,12 @@ variable "route53_zone_name" {
   description = "The name of the Route53 zone"
 }
 
+variable "create_custom_domain_record" {
+  type        = bool
+  description = "Define if a custom domain record should be created"
+  default     = false
+}
+
 variable "tags" {
   type        = map(string)
   description = "A map of tags to add to all resources"

--- a/lb-domain/variables.tf
+++ b/lb-domain/variables.tf
@@ -19,6 +19,12 @@ variable "create_custom_domain_record" {
   default     = false
 }
 
+variable "custom_domain_record_value" {
+  type        = string
+  description = "The value of the custom domain record"
+  default     = "custom-loadbalancer"
+}
+
 variable "tags" {
   type        = map(string)
   description = "A map of tags to add to all resources"


### PR DESCRIPTION
## Description

This pull request extends `lb-domain` module by adding a possibility to create dns entry for a domain used by `custom domains` feature. Once enabled, defined DNS recored will be added to the main domain zone with the value of dedicated AWS Network Load Balalancer.

## Related Issue(s)

Closes https://github.com/FlowFuse/terraform-aws-flowfuse/issues/8

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

