### PR TITLE
feat(eks): Add possibility to define independent kubernetes version for each node group

### DIFF
--- a/eks/main.tf
+++ b/eks/main.tf
@@ -46,7 +46,7 @@ module "node_groups" {
   for_each                    = var.eks_node_groups
   subnet_ids                  = data.aws_subnets.private.ids
   cluster_name                = module.eks_cluster.eks_cluster_id
-  kubernetes_version          = [var.kubernetes_version]
+  kubernetes_version          = each.value.kubernetes_version
   instance_types              = each.value.instance_types
   ami_type                    = each.value.ami_type
   desired_size                = each.value.desired_size

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -80,6 +80,7 @@ variable "eks_node_groups" {
     * `desired_size` - desired number of instances
     * `min_size` - minimum number of instances
     * `max_size` - maximum number of instances
+    * `kubernetes_version` - Kubernetes version for the node group
     * `kubernetes_labels` - Kubernetes labels to apply to the node group
     * `cluster_autoscaler_enabled` - whether to enable the cluster autoscaler for the node group
     * `detailed_monitoring_enabled` - whether to enable detailed monitoring for the node group

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -66,6 +66,7 @@ variable "eks_node_groups" {
     desired_size                = number
     min_size                    = number
     max_size                    = number
+    kubernetes_version          = list(string)
     kubernetes_labels           = map(string)
     cluster_autoscaler_enabled  = bool
     detailed_monitoring_enabled = bool
@@ -92,6 +93,7 @@ variable "eks_node_groups" {
       desired_size   = 1
       min_size       = 1
       max_size       = 2
+      kubernetes_version = ["1.26"]
       kubernetes_labels = {
         role = "management"
       }
@@ -106,6 +108,7 @@ variable "eks_node_groups" {
       desired_size   = 1
       min_size       = 1
       max_size       = 4
+      kubernetes_version = ["1.26"]
       kubernetes_labels = {
         role = "projects"
       }


### PR DESCRIPTION
## Description

This pull requests extends the `eks` module by adding a possibility to specify custom kubernetes version for each node group. 

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

