### PR TITLE
feat(rds): Enable performamce insight on primary rds instance

### DIFF
--- a/rds/README.md
+++ b/rds/README.md
@@ -39,14 +39,14 @@ The module also provides several outputs including the database address, name, p
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.44.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.49.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.1 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_primary"></a> [primary](#module\_primary) | cloudposse/rds/aws | 1.1.0 |
+| <a name="module_primary"></a> [primary](#module\_primary) | cloudposse/rds/aws | 1.1.2 |
 | <a name="module_rds_subnets"></a> [rds\_subnets](#module\_rds\_subnets) | cloudposse/dynamic-subnets/aws | 2.4.2 |
 | <a name="module_rds_vpc"></a> [rds\_vpc](#module\_rds\_vpc) | cloudposse/vpc/aws | 2.2.0 |
 | <a name="module_replica"></a> [replica](#module\_replica) | cloudposse/rds/aws | 1.1.0 |

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -45,41 +45,43 @@ data "aws_vpc" "this" {
 
 module "primary" {
   source  = "cloudposse/rds/aws"
-  version = "1.1.0"
+  version = "1.1.2"
 
   namespace = var.namespace
   stage     = var.stage
   name      = "flowfuse"
   host_name = "db"
   # security_group_ids = [data.aws_vpc.this.cidr_block]
-  ca_cert_identifier          = "rds-ca-ecc384-g1"
-  allowed_cidr_blocks         = [data.aws_vpc.this.cidr_block]
-  database_name               = var.database_name
-  database_user               = var.database_user
-  database_password           = random_password.database_password.result
-  database_port               = var.database_port
-  multi_az                    = false
-  storage_type                = "gp2"
-  allocated_storage           = 10
-  storage_encrypted           = true
-  engine                      = "postgres"
-  engine_version              = "14.10"
-  major_engine_version        = "14"
-  instance_class              = "db.t4g.small"
-  db_parameter_group          = "postgres14"
-  publicly_accessible         = false
-  vpc_id                      = module.rds_vpc.vpc_id
-  subnet_ids                  = module.rds_subnets.private_subnet_ids
-  auto_minor_version_upgrade  = false
-  allow_major_version_upgrade = false
-  apply_immediately           = false
-  maintenance_window          = "Mon:03:00-Mon:04:00"
-  skip_final_snapshot         = true
-  copy_tags_to_snapshot       = true
-  backup_retention_period     = 7
-  backup_window               = "00:52-01:52"
-  deletion_protection         = false
-  tags                        = var.tags
+  ca_cert_identifier                    = "rds-ca-ecc384-g1"
+  allowed_cidr_blocks                   = [data.aws_vpc.this.cidr_block]
+  database_name                         = var.database_name
+  database_user                         = var.database_user
+  database_password                     = random_password.database_password.result
+  database_port                         = var.database_port
+  multi_az                              = false
+  storage_type                          = "gp2"
+  allocated_storage                     = 10
+  storage_encrypted                     = true
+  engine                                = "postgres"
+  engine_version                        = "14.10"
+  major_engine_version                  = "14"
+  instance_class                        = "db.t4g.small"
+  db_parameter_group                    = "postgres14"
+  publicly_accessible                   = false
+  vpc_id                                = module.rds_vpc.vpc_id
+  subnet_ids                            = module.rds_subnets.private_subnet_ids
+  auto_minor_version_upgrade            = false
+  allow_major_version_upgrade           = false
+  apply_immediately                     = false
+  maintenance_window                    = "Mon:03:00-Mon:04:00"
+  skip_final_snapshot                   = true
+  copy_tags_to_snapshot                 = true
+  backup_retention_period               = 7
+  backup_window                         = "00:52-01:52"
+  deletion_protection                   = false
+  performance_insights_enabled          = true
+  performance_insights_retention_period = 7
+  tags                                  = var.tags
 
 }
 


### PR DESCRIPTION
## Description

This pull request enables RDS Performance Insights in priomary RDS instance and sets retention period to 7 days.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

