### PR TITLE
feat: Separate IAM role creation from assigning permissions to the service account 

### DIFF
--- a/eks/iam_role.tf
+++ b/eks/iam_role.tf
@@ -1,4 +1,4 @@
-module "eks_ses_iam_role" {
+module "flowfuse_iam_role" {
   source  = "cloudposse/eks-iam-role/aws"
   version = "2.2.1"
 

--- a/eks/iam_role.tf
+++ b/eks/iam_role.tf
@@ -1,0 +1,14 @@
+module "eks_ses_iam_role" {
+  source  = "cloudposse/eks-iam-role/aws"
+  version = "2.2.1"
+
+  namespace = var.namespace
+  stage     = var.stage
+
+  aws_account_number          = one(data.aws_caller_identity.current[*].account_id)
+  eks_cluster_oidc_issuer_url = module.eks_cluster.eks_cluster_identity_oidc_issuer
+
+  service_account_name      = "flowfuse"
+  service_account_namespace = "default"
+}
+

--- a/eks/iam_role.tf
+++ b/eks/iam_role.tf
@@ -8,7 +8,7 @@ module "eks_ses_iam_role" {
   aws_account_number          = one(data.aws_caller_identity.current[*].account_id)
   eks_cluster_oidc_issuer_url = module.eks_cluster.eks_cluster_identity_oidc_issuer
 
-  service_account_name      = "flowfuse"
+  service_account_name      = "flowforge"
   service_account_namespace = "default"
 }
 

--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -6,6 +6,6 @@ output "cluster_oidc_issuer_url" {
   value = module.eks_cluster.eks_cluster_identity_oidc_issuer
 }
 
-output "application_iam_role_name" {
+output "flowfuse_ses_role_arn" {
   value = module.eks_ses_iam_role.service_account_role_name
 }

--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -5,3 +5,7 @@ output "cluster_name" {
 output "cluster_oidc_issuer_url" {
   value = module.eks_cluster.eks_cluster_identity_oidc_issuer
 }
+
+output "application_iam_role_name" {
+  value = module.eks_ses_iam_role.service_account_role_name
+}

--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -6,6 +6,6 @@ output "cluster_oidc_issuer_url" {
   value = module.eks_cluster.eks_cluster_identity_oidc_issuer
 }
 
-output "flowfuse_ses_role_arn" {
+output "flowfuse_role_arn" {
   value = module.eks_ses_iam_role.service_account_role_name
 }

--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -7,5 +7,5 @@ output "cluster_oidc_issuer_url" {
 }
 
 output "flowfuse_role_arn" {
-  value = module.eks_ses_iam_role.service_account_role_name
+  value = module.flowfuse_iam_role.service_account_role_name
 }

--- a/ses/main.tf
+++ b/ses/main.tf
@@ -74,7 +74,7 @@ data "aws_iam_policy_document" "ses" {
 }
 
 data "aws_iam_roles" "application_role" {
-  name_regex = ".*flowfuse@default.*"
+  name_regex = ".*flowforge@default.*"
 }
 
 resource "aws_iam_policy" "ses-policy" {

--- a/ses/main.tf
+++ b/ses/main.tf
@@ -48,6 +48,7 @@ module "dmarc_record" {
 module "eks_ses_iam_role" {
   source  = "cloudposse/eks-iam-role/aws"
   version = "2.1.1"
+  enabled = false
 
   namespace = var.namespace
   stage     = var.stage

--- a/ses/main.tf
+++ b/ses/main.tf
@@ -72,3 +72,18 @@ data "aws_iam_policy_document" "ses" {
     ]
   }
 }
+
+data "aws_iam_roles" "application_role" {
+  name_regex = ".*flowfuse@default.*"
+}
+
+resource "aws_iam_policy" "ses-policy" {
+  name        = "FlowFuseSesPolicy"
+  description = "Allows sending email via SES"
+  policy      = data.aws_iam_policy_document.policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "ses" {
+  role        = data.aws_iam_roles.application_role.roles[0].name
+  policy_arn  = aws_iam_policy.ses-policy.arn
+}

--- a/ses/main.tf
+++ b/ses/main.tf
@@ -45,22 +45,6 @@ module "dmarc_record" {
   ]
 }
 
-module "eks_ses_iam_role" {
-  source  = "cloudposse/eks-iam-role/aws"
-  version = "2.1.1"
-  enabled = false
-
-  namespace = var.namespace
-  stage     = var.stage
-
-  aws_account_number          = one(data.aws_caller_identity.current[*].account_id)
-  eks_cluster_oidc_issuer_url = data.aws_eks_cluster.this.identity[0].oidc[0].issuer
-
-  service_account_name      = "flowforge"
-  service_account_namespace = "default"
-  aws_iam_policy_document   = [data.aws_iam_policy_document.ses.json]
-}
-
 data "aws_iam_policy_document" "ses" {
   statement {
     sid    = "AllowToSendEmailsViaSes"

--- a/ses/main.tf
+++ b/ses/main.tf
@@ -84,6 +84,6 @@ resource "aws_iam_policy" "ses-policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "ses" {
-  role        = data.aws_iam_roles.application_role.roles[0].name
+  role        = data.aws_iam_roles.application_role.names[0]
   policy_arn  = aws_iam_policy.ses-policy.arn
 }

--- a/ses/main.tf
+++ b/ses/main.tf
@@ -80,7 +80,7 @@ data "aws_iam_roles" "application_role" {
 resource "aws_iam_policy" "ses-policy" {
   name        = "FlowFuseSesPolicy"
   description = "Allows sending email via SES"
-  policy      = data.aws_iam_policy_document.policy.json
+  policy      = data.aws_iam_policy_document.ses.json
 }
 
 resource "aws_iam_role_policy_attachment" "ses" {

--- a/ses/main.tf
+++ b/ses/main.tf
@@ -84,6 +84,6 @@ resource "aws_iam_policy" "ses-policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "ses" {
-  role        = data.aws_iam_roles.application_role.names
+  role        = one(data.aws_iam_roles.application_role.names)
   policy_arn  = aws_iam_policy.ses-policy.arn
 }

--- a/ses/main.tf
+++ b/ses/main.tf
@@ -84,6 +84,6 @@ resource "aws_iam_policy" "ses-policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "ses" {
-  role        = data.aws_iam_roles.application_role.names[0]
+  role        = data.aws_iam_roles.application_role.names
   policy_arn  = aws_iam_policy.ses-policy.arn
 }

--- a/ses/outputs.tf
+++ b/ses/outputs.tf
@@ -1,3 +1,0 @@
-output "flowfuse_ses_role_arn" {
-  value = module.eks_ses_iam_role.service_account_role_arn
-}


### PR DESCRIPTION
## Description

This pull request moves AWS IAM role creation (role assumed by the service account used by the FlowFuse core deployment) from `ses` module to `eks` one.
The main motivation is to create a role with empty permissions together with an EKS cluster and assign policies in different places - when it is required. This approach adds the possibility of attaching more than one policy to the role.  

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

